### PR TITLE
Cleanup as well as some prep for workshop readiness

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,85 +1,51 @@
-#!/usr/bin/env python3
-
-# cdk: 1.25.0
 from aws_cdk import (
-    aws_ec2,
-    aws_ecs,
-    aws_ecs_patterns,
-    aws_iam,
-    aws_servicediscovery,
-    core,
-    aws_ssm,
-
+    core as cdk,
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    aws_ecr_assets as ecr_a,
+    aws_iam as iam,
+    aws_logs as logs,
 )
 
 from os import getenv
 
 
-# Creating a construct that will populate the required objects created in the platform repo such as vpc, ecs cluster, and service discovery namespace
-class BasePlatform(core.Construct):
+class AmpService(cdk.Stack):
 
-    def __init__(self, scope: core.Construct, id: str, **kwargs):
-        super().__init__(scope, id, **kwargs)
-        self.environment_name = 'ecsworkshop'
-
-        # The base platform stack is where the VPC was created, so all we need is the name to do a lookup and import it into this stack for use
-        self.vpc = aws_ec2.Vpc.from_lookup(
-            self, "VPC",
-            vpc_name='{}-base/BaseVPC'.format(self.environment_name)
-        )
-
-        self.sd_namespace = aws_servicediscovery.PrivateDnsNamespace.from_private_dns_namespace_attributes(
-            self, "SDNamespace",
-            namespace_name=core.Fn.import_value('NSNAME'),
-            namespace_arn=core.Fn.import_value('NSARN'),
-            namespace_id=core.Fn.import_value('NSID')
-        )
-
-        self.ecs_cluster = aws_ecs.Cluster.from_cluster_attributes(
-            self, "ECSCluster",
-            cluster_name=core.Fn.import_value('ECSClusterName'),
-            security_groups=[],
-            vpc=self.vpc,
-            default_cloud_map_namespace=self.sd_namespace
-        )
-
-        self.services_sec_grp = aws_ec2.SecurityGroup.from_security_group_id(
-            self, "ServicesSecGrp",
-            security_group_id=core.Fn.import_value('ServicesSecGrp')
-        )
-
-
-class AmpService(core.Stack):
-
-    def __init__(self, scope: core.Stack, id: str, **kwargs):
+    def __init__(self, scope: cdk.Stack, id: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
-        self.base_platform = BasePlatform(self, self.stack_name)
+        self.vpc = ec2.Vpc(self, "VPC")
 
-        file = open("ecs-fargate-adot-config.yaml")
-        adot_config = file.read()
-        file.close()
+        self.ecs_cluster = ecs.Cluster(self, "DemoCluster", vpc=self.vpc)
 
-        exec_role = aws_iam.Role(
-            self, 'AmpAppTaskExecutionRole-',
-            assumed_by=aws_iam.ServicePrincipal('ecs-tasks.amazonaws.com'))
-        exec_role.add_managed_policy(aws_iam.ManagedPolicy.from_aws_managed_policy_name('service-role/AmazonECSTaskExecutionRolePolicy'))
-        exec_role.add_managed_policy(aws_iam.ManagedPolicy.from_aws_managed_policy_name('AmazonSSMReadOnlyAccess'))
+        with open("ecs-fargate-adot-config.yaml", 'r') as f:
+            adot_config = f.read()
 
-        self.fargate_task_def = aws_ecs.TaskDefinition(
+        self.fargate_task_def = ecs.TaskDefinition(
             self, "aws-otel-FargateTask",
-            compatibility=aws_ecs.Compatibility.EC2_AND_FARGATE,
+            compatibility=ecs.Compatibility.EC2_AND_FARGATE,
             cpu='256',
-            memory_mib='1024',
-            execution_role=exec_role
+            memory_mib='1024'
         )
 
-        self.container = self.fargate_task_def.add_container(
+        self.adot_log_grp = logs.LogGroup(
+            self, "AdotLogGroup",
+            removal_policy=cdk.RemovalPolicy.DESTROY
+        )
+
+        self.app_log_grp = logs.LogGroup(
+            self, "AppLogGroup",
+            removal_policy=cdk.RemovalPolicy.DESTROY
+        )
+
+        self.otel_container = self.fargate_task_def.add_container(
             "aws-otel-collector",
-            image=aws_ecs.ContainerImage.from_registry("public.ecr.aws/aws-observability/aws-otel-collector:latest"),
+            image=ecs.ContainerImage.from_registry("public.ecr.aws/aws-observability/aws-otel-collector:latest"),
             memory_reservation_mib=512,
-            logging=aws_ecs.LogDriver.aws_logs(
-                stream_prefix='/ecs/ecs-aws-otel-sidecar-collector-cdk'
+            logging=ecs.LogDriver.aws_logs(
+                stream_prefix='/ecs/ecs-aws-otel-sidecar-collector-cdk',
+                log_group=self.adot_log_grp
             ),
             environment={
                 "REGION": getenv('AWS_REGION'),
@@ -87,46 +53,49 @@ class AmpService(core.Stack):
             },
         )
 
-        self.container = self.fargate_task_def.add_container(
+        self.prom_container = self.fargate_task_def.add_container(
             "prometheus-sample-app",
-            image=aws_ecs.ContainerImage.from_registry("public.ecr.aws/pkashlik/prometheus-sample-app:latest"),
+            image=ecs.ContainerImage.from_docker_image_asset(
+                asset=ecr_a.DockerImageAsset(
+                    self, "PromAppImage",
+                    directory='../prometheus'
+                )
+            ),
             memory_reservation_mib=256,
-            logging=aws_ecs.LogDriver.aws_logs(
-                stream_prefix='/ecs/prometheus-sample-app-cdk'
+            logging=ecs.LogDriver.aws_logs(
+                stream_prefix='/ecs/prometheus-sample-app-cdk',
+                log_group=self.app_log_grp
             ),
             environment={
                 "REGION": getenv('AWS_REGION')
             },
         )
 
-        self.fargate_service = aws_ecs.FargateService(
+        self.fargate_service = ecs.FargateService(
             self, "AmpFargateService",
             service_name='aws-otel-FargateService',
             task_definition=self.fargate_task_def,
-            cluster=self.base_platform.ecs_cluster,
-            security_group=self.base_platform.services_sec_grp,
+            cluster=self.ecs_cluster,
             desired_count=1,
-            cloud_map_options=aws_ecs.CloudMapOptions(
-                cloud_map_namespace=self.base_platform.sd_namespace,
-                name='aws-otel-FargateService'
-            )
         )
 
         self.fargate_task_def.add_to_task_role_policy(
-            aws_iam.PolicyStatement(
-                actions=[ "logs:PutLogEvents","logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:DescribeLogStreams",
-                "logs:DescribeLogGroups",
-                "ssm:GetParameters",
-                "aps:RemoteWrite"],
+            iam.PolicyStatement(
+                actions=[
+                    "logs:PutLogEvents",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:DescribeLogStreams",
+                    "logs:DescribeLogGroups",
+                    "ssm:GetParameters",
+                    "aps:RemoteWrite"
+                ],
                 resources=['*']
             )
         )
 
-_env = core.Environment(account=getenv('AWS_ACCOUNT_ID'), region=getenv('AWS_DEFAULT_REGION'))
-environment = "ecsworkshop"
-stack_name = "{}-amp".format(environment)
-app = core.App()
-AmpService(app, stack_name, env=_env)
+
+_env = cdk.Environment(account=getenv('AWS_ACCOUNT_ID'), region=getenv('AWS_DEFAULT_REGION'))
+app = cdk.App()
+AmpService(app, "ecsworkshopAmpDemo", env=_env)
 app.synth()

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,6 +1,6 @@
-aws_cdk.aws_ecs_patterns
+aws_cdk.core
 aws_cdk.aws_ec2
 aws_cdk.aws_ecs
-aws_cdk.aws_ecs_patterns
-aws_cdk.aws_servicediscovery
-aws_cdk.core
+aws_cdk.aws_ecr_assets
+aws_cdk.aws_iam
+aws_cdk.aws_logs


### PR DESCRIPTION
*Description of changes:*

Cleanup on imports to follow cdk standards
Removing base platform and creating vpc and cluster inside of stack
Building application image in cdk, not relying on centrally hosted image
Adding a removal policy to the log groups to ensure they get destroyed on deletion of stack
Other minor cleanup items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
