### PR TITLE
Use v0.20.0 of the aws-otel-collector image

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -41,7 +41,7 @@ class AmpService(cdk.Stack):
 
         self.otel_container = self.fargate_task_def.add_container(
             "aws-otel-collector",
-            image=ecs.ContainerImage.from_registry("public.ecr.aws/aws-observability/aws-otel-collector:latest"),
+            image=ecs.ContainerImage.from_registry("public.ecr.aws/aws-observability/aws-otel-collector:v0.20.0"),
             memory_reservation_mib=512,
             logging=ecs.LogDriver.aws_logs(
                 stream_prefix='/ecs/ecs-aws-otel-sidecar-collector-cdk',


### PR DESCRIPTION
According to https://github.com/aws-observability/aws-otel-collector, awsprometheusremotewriteexporter is removed in v0.21.0, which we used in ecs-fargate-adot-config.yaml. Hence, we need to specify the aws-otel-collector image to a version < v0.21.0.

*Issue #, if available:*
N/A

*Description of changes:*
According to https://github.com/aws-observability/aws-otel-collector, awsprometheusremotewriteexporter is removed in v0.21.0, which we used in ecs-fargate-adot-config.yaml. Hence, we need to specify the aws-otel-collector image to a version < v0.21.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
