### PR TITLE
Update ecs-fargate-adot-config.yaml

### DIFF
--- a/cdk/ecs-fargate-adot-config.yaml
+++ b/cdk/ecs-fargate-adot-config.yaml
@@ -28,34 +28,34 @@ processors:
           - ecs.task.storage.write_bytes
   metricstransform: # update metric names
     transforms:
-      - metric_name: ecs.task.memory.utilized
+      - include: ecs.task.memory.utilized
         action: update
         new_name: MemoryUtilized
-      - metric_name: ecs.task.memory.reserved
+      - include: ecs.task.memory.reserved
         action: update
         new_name: MemoryReserved
-      - metric_name: ecs.task.memory.usage
+      - include: ecs.task.memory.usage
         action: update
         new_name: MemoryUsage
-      - metric_name: ecs.task.cpu.utilized
+      - include: ecs.task.cpu.utilized
         action: update
         new_name: CpuUtilized
-      - metric_name: ecs.task.cpu.reserved
+      - include: ecs.task.cpu.reserved
         action: update
         new_name: CpuReserved
-      - metric_name: ecs.task.cpu.usage.vcpu
+      - include: ecs.task.cpu.usage.vcpu
         action: update
         new_name: CpuUsage
-      - metric_name: ecs.task.network.rate.rx
+      - include: ecs.task.network.rate.rx
         action: update
         new_name: NetworkRxBytes
-      - metric_name: ecs.task.network.rate.tx
+      - include: ecs.task.network.rate.tx
         action: update
         new_name: NetworkTxBytes
-      - metric_name: ecs.task.storage.read_bytes
+      - include: ecs.task.storage.read_bytes
         action: update
         new_name: StorageReadBytes
-      - metric_name: ecs.task.storage.write_bytes
+      - include: ecs.task.storage.write_bytes
         action: update
         new_name: StorageWriteBytes
   resource:
@@ -81,13 +81,10 @@ processors:
       - key: aws.ecs.task.family
         action: delete
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: {{endpoint}}
-    aws_auth:
-      region: {{region}}
-      service: "aps"
-    resource_to_telemetry_conversion:
-      enabled: true
+    auth:
+      authenticator: sigv4auth
   logging:
     loglevel: debug
 extensions:
@@ -96,13 +93,15 @@ extensions:
     endpoint: :1888
   zpages:
     endpoint: :55679
+  sigv4auth:
+    region: {{region}}
 service:
-  extensions: [pprof, zpages, health_check]
+  extensions: [pprof, zpages, health_check, sigv4auth]
   pipelines:
     metrics:
       receivers: [prometheus]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]
     metrics/ecs:
       receivers: [awsecscontainermetrics]
       processors: [filter]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]


### PR DESCRIPTION
Updating the file to fix the Open-telemetry deprecations as per below:

* [Remove deprecated metric_name setting #12737](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12737) - It was replaced by `include` as per [the docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
* [awsprometheusremotewriteexporter deprecation notice](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter#section-readme) - Users who want to send metrics to Amazon Managed Service for Prometheus will need to instead use the [Prometheus Remote Write Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md) along with the [Sigv4 Authenticator Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/sigv4authextension/README.md) to achieve the same result.

*Issue #, if available:*

Opened on ECS Workshop GitHub Page: https://github.com/aws-containers/ecsworkshop/issues/65

*Description of changes:*

The changes are aligned to the new way to configure the configuration file for the image `public.ecr.aws/aws-observability/aws-otel-collector:latest`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
